### PR TITLE
Add in-memory rate limiting for IP-based request throttling

### DIFF
--- a/src/main/java/am/ik/blog/BlogFrontendApplication.java
+++ b/src/main/java/am/ik/blog/BlogFrontendApplication.java
@@ -5,9 +5,11 @@ import java.time.Instant;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class BlogFrontendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/am/ik/blog/config/SecurityConfig.java
+++ b/src/main/java/am/ik/blog/config/SecurityConfig.java
@@ -1,17 +1,34 @@
 package am.ik.blog.config;
 
+import am.ik.blog.ratelimit.RateLimitFilter;
+import am.ik.blog.ratelimit.RateLimitProperties;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(RateLimitProperties.class)
 public class SecurityConfig {
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	@ConditionalOnProperty(name = "rate-limit.enabled", havingValue = "true")
+	public RateLimitFilter rateLimitFilter(RateLimitProperties rateLimitProperties) {
+		return new RateLimitFilter(rateLimitProperties.maxRequests(), rateLimitProperties.window().toMillis());
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http,
+			ObjectProvider<RateLimitFilter> rateLimitFilterProvider) throws Exception {
+		rateLimitFilterProvider
+			.ifAvailable(filter -> http.addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class));
 		return http.authorizeHttpRequests(authorize -> authorize
 		// @formatter:off
 				.requestMatchers("/api/google/**").authenticated()

--- a/src/main/java/am/ik/blog/ratelimit/RateLimitFilter.java
+++ b/src/main/java/am/ik/blog/ratelimit/RateLimitFilter.java
@@ -1,0 +1,106 @@
+package am.ik.blog.ratelimit;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Simple in-memory rate limiting filter based on IP address. Uses a sliding window
+ * approach to limit requests per IP within a configurable time window.
+ */
+public class RateLimitFilter extends OncePerRequestFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(RateLimitFilter.class);
+
+	private final ConcurrentHashMap<String, RequestCounter> requestCounts = new ConcurrentHashMap<>();
+
+	private final int maxRequests;
+
+	private final long windowSizeMillis;
+
+	public RateLimitFilter(int maxRequests, long windowSizeMillis) {
+		this.maxRequests = maxRequests;
+		this.windowSizeMillis = windowSizeMillis;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		String clientIp = getClientIp(request);
+		long now = Instant.now().toEpochMilli();
+
+		RequestCounter counter = requestCounts.compute(clientIp, (ip, existing) -> {
+			if (existing == null || existing.isExpired(now, windowSizeMillis)) {
+				return new RequestCounter(now);
+			}
+			return existing;
+		});
+
+		int currentCount = counter.incrementAndGet();
+
+		if (currentCount > maxRequests) {
+			log.warn("Rate limit exceeded for IP: {} (count: {}, limit: {})", clientIp, currentCount, maxRequests);
+			response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+			response.setContentType("application/json");
+			response.getWriter().write("{\"error\":\"Too many requests. Please try again later.\"}");
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String getClientIp(HttpServletRequest request) {
+		// Check X-Forwarded-For header for proxied requests
+		String xForwardedFor = request.getHeader("X-Forwarded-For");
+		if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+			// Take the first IP in the chain (original client)
+			return xForwardedFor.split(",")[0].trim();
+		}
+		// Check X-Real-IP header
+		String xRealIp = request.getHeader("X-Real-IP");
+		if (xRealIp != null && !xRealIp.isEmpty()) {
+			return xRealIp.trim();
+		}
+		return request.getRemoteAddr();
+	}
+
+	@Scheduled(fixedRateString = "${rate-limit.window:60000}")
+	public void cleanupExpiredEntries() {
+		long now = Instant.now().toEpochMilli();
+		requestCounts.entrySet().removeIf(entry -> entry.getValue().isExpired(now, windowSizeMillis));
+	}
+
+	private static class RequestCounter {
+
+		private final long windowStart;
+
+		private final AtomicInteger count;
+
+		RequestCounter(long windowStart) {
+			this.windowStart = windowStart;
+			this.count = new AtomicInteger(0);
+		}
+
+		int incrementAndGet() {
+			return count.incrementAndGet();
+		}
+
+		boolean isExpired(long now, long windowSizeMillis) {
+			return now - windowStart > windowSizeMillis;
+		}
+
+	}
+
+}

--- a/src/main/java/am/ik/blog/ratelimit/RateLimitProperties.java
+++ b/src/main/java/am/ik/blog/ratelimit/RateLimitProperties.java
@@ -1,0 +1,11 @@
+package am.ik.blog.ratelimit;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "rate-limit")
+public record RateLimitProperties(@DefaultValue("false") boolean enabled, @DefaultValue("100") int maxRequests,
+		@DefaultValue("1m") Duration window) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,7 @@ spring.security.oauth2.client.registration.google.scope=openid,profile,email
 spring.web.resources.cache.period=1d
 spring.web.resources.cache.use-last-modified=false
 translation-api.url=https://translation-api.lemon.maki.lol
+# Rate limiting configuration
+rate-limit.enabled=true
+rate-limit.max-requests=100
+rate-limit.window=1m

--- a/src/test/java/am/ik/blog/ratelimit/RateLimitFilterTest.java
+++ b/src/test/java/am/ik/blog/ratelimit/RateLimitFilterTest.java
@@ -1,0 +1,90 @@
+package am.ik.blog.ratelimit;
+
+import am.ik.blog.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = { "rate-limit.enabled=true", "rate-limit.max-requests=5", "rate-limit.window=1m" })
+class RateLimitFilterTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	void shouldReturn429WhenRateLimitExceeded() throws Exception {
+		// First 5 requests should succeed
+		for (int i = 0; i < 5; i++) {
+			this.mvc.perform(get("/test")).andExpect(status().isOk());
+		}
+
+		// 6th request should be rate limited
+		this.mvc.perform(get("/test"))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(jsonPath("$.error").value("Too many requests. Please try again later."));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestConfig {
+
+		@Bean
+		TestController testController() {
+			return new TestController();
+		}
+
+	}
+
+	@RestController
+	static class TestController {
+
+		@GetMapping(path = "/test", produces = MediaType.APPLICATION_JSON_VALUE)
+		String test() {
+			return "{\"message\":\"ok\"}";
+		}
+
+	}
+
+}
+
+@WebMvcTest
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = { "rate-limit.enabled=false", "rate-limit.max-requests=5", "rate-limit.window=1m" })
+class RateLimitFilterDisabledTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	void shouldNotRateLimitWhenDisabled() throws Exception {
+		// All requests should succeed even beyond the max-requests limit
+		for (int i = 0; i < 10; i++) {
+			this.mvc.perform(get("/test")).andExpect(status().isOk());
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestConfig {
+
+		@Bean
+		RateLimitFilterTest.TestController testController() {
+			return new RateLimitFilterTest.TestController();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add simple in-memory rate limiting filter to block excessive requests from specific IP addresses
- Configurable via `rate-limit.enabled`, `rate-limit.max-requests`, and `rate-limit.window` properties
- Support for proxied requests via `X-Forwarded-For` and `X-Real-IP` headers
- Periodic cleanup of expired entries to prevent memory leaks

## Test plan

- [x] Verify rate limiting returns 429 when max requests exceeded
- [x] Verify rate limiting is disabled when `rate-limit.enabled=false`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)