### PR TITLE
Add bot blocking filter for WordPress-related spam paths

### DIFF
--- a/src/main/java/am/ik/blog/security/BotBlockingFilter.java
+++ b/src/main/java/am/ik/blog/security/BotBlockingFilter.java
@@ -1,0 +1,42 @@
+package am.ik.blog.security;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter to silently block bot access to common spam paths. This filter matches request
+ * URIs against configured regex patterns and returns 410 Gone for matches without logging
+ * to reduce noise from automated bot scanning.
+ */
+public class BotBlockingFilter extends OncePerRequestFilter {
+
+	private final List<Pattern> patterns;
+
+	public BotBlockingFilter(List<String> patternStrings) {
+		this.patterns = patternStrings.stream().map(Pattern::compile).toList();
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		String requestPath = request.getRequestURI();
+
+		// Block paths matching configured patterns silently
+		if (requestPath != null && patterns.stream().anyMatch(pattern -> pattern.matcher(requestPath).find())) {
+			response.setStatus(HttpStatus.GONE.value());
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+}

--- a/src/main/java/am/ik/blog/security/BotBlockingProperties.java
+++ b/src/main/java/am/ik/blog/security/BotBlockingProperties.java
@@ -1,0 +1,15 @@
+package am.ik.blog.security;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Configuration properties for bot blocking filter. Allows specifying multiple regex
+ * patterns to match against request URIs for blocking bot access.
+ */
+@ConfigurationProperties(prefix = "bot-blocking")
+public record BotBlockingProperties(@DefaultValue( {
+		"/wp-" }) List<String> patterns){
+}

--- a/src/test/java/am/ik/blog/security/BotBlockingFilterTest.java
+++ b/src/test/java/am/ik/blog/security/BotBlockingFilterTest.java
@@ -1,0 +1,65 @@
+package am.ik.blog.security;
+
+import am.ik.blog.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import(SecurityConfig.class)
+class BotBlockingFilterTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	void shouldBlockWordPressPathsWithWpPrefix() throws Exception {
+		this.mvc.perform(get("/wp-admin")).andExpect(status().isGone());
+		this.mvc.perform(get("/wp-login.php")).andExpect(status().isGone());
+		this.mvc.perform(get("/wp-content/uploads/file.jpg")).andExpect(status().isGone());
+		this.mvc.perform(get("/blog/wp-admin")).andExpect(status().isGone());
+	}
+
+	@Test
+	void shouldAllowNormalPaths() throws Exception {
+		this.mvc.perform(get("/test")).andExpect(status().isOk());
+		this.mvc.perform(get("/api/entries")).andExpect(status().isOk());
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestConfig {
+
+		@Bean
+		TestController testController() {
+			return new TestController();
+		}
+
+	}
+
+	@RestController
+	static class TestController {
+
+		@GetMapping(path = "/test", produces = MediaType.APPLICATION_JSON_VALUE)
+		String test() {
+			return "{\"message\":\"ok\"}";
+		}
+
+		@GetMapping(path = "/api/entries", produces = MediaType.APPLICATION_JSON_VALUE)
+		String entries() {
+			return "{\"entries\":[]}";
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Implement a configurable filter to silently block bot access to common spam paths
- Returns 410 Gone for matching paths without logging to reduce noise
- Default pattern blocks WordPress-related URLs (`/wp-`)

## Changes
- Add `BotBlockingFilter` that returns 410 Gone for matching request URIs
- Add `BotBlockingProperties` for regex pattern configuration via `bot-blocking.patterns`
- Register filter before `SecurityContextHolderFilter` for early request blocking
- Use `Pattern.find()` for flexible partial matching
- Add comprehensive unit tests for filter behavior

## Configuration
Default configuration blocks paths containing `/wp-`:
```yaml
bot-blocking:
  patterns:
    - "/wp-"
```

Additional patterns can be configured:
```yaml
bot-blocking:
  patterns:
    - "/wp-"              # WordPress
    - "/\\.env"           # Environment files
    - "/phpmyadmin/"      # phpMyAdmin
```

## Test plan
- [x] Unit tests verify WordPress paths are blocked with 410 Gone
- [x] Normal paths continue to work as expected
- [x] All existing tests pass
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)