### PR TITLE
Add Markdown view button to entry page

### DIFF
--- a/ui/src/components/icons/index.tsx
+++ b/ui/src/components/icons/index.tsx
@@ -476,18 +476,26 @@ export const ChevronDownIcon: React.FC<{ className?: string }> = ({ className = 
 
 // Chevron Right icon for collapsible elements
 export const ChevronRightIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) => (
-  <svg 
-    xmlns="http://www.w3.org/2000/svg" 
-    className={className} 
-    fill="none" 
-    viewBox="0 0 24 24" 
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    fill="none"
+    viewBox="0 0 24 24"
     stroke="currentColor"
   >
-    <path 
-      strokeLinecap="round" 
-      strokeLinejoin="round" 
-      strokeWidth={2} 
-      d="M9 5l7 7-7 7" 
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 5l7 7-7 7"
     />
+  </svg>
+);
+
+// Markdown icon for raw markdown content (MD in a square box, similar to JaIcon/EnIcon)
+export const MarkdownIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+    <rect x="2" y="2" width="20" height="20" rx="2" strokeWidth="1.5" />
+    <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fill="currentColor" fontSize="9" fontWeight="bold" fontFamily="sans-serif">MD</text>
   </svg>
 );

--- a/ui/src/pages/entry/EntryPage.tsx
+++ b/ui/src/pages/entry/EntryPage.tsx
@@ -13,7 +13,7 @@ import {ShareWithX} from "../../components/ShareWithX.tsx";
 import {ShareWithBlueSky} from "../../components/ShareWithBlueSky.tsx";
 import {ShareWithHatebu} from "../../components/ShareWithHatebu.tsx";
 import {NotTranslated} from "./NotTranslated.tsx";
-import {CalendarIcon, EditIcon, EyeIcon, FolderIcon, InfoIcon} from "../../components/icons";
+import {CalendarIcon, EditIcon, EyeIcon, FolderIcon, InfoIcon, MarkdownIcon} from "../../components/icons";
 import {Entry, getEntry} from "../../api/entryApi";
 import {ApiError, ProblemDetail} from "../../utils/fetch";
 import EntryTag from "../../components/EntryTag";
@@ -164,10 +164,19 @@ const EntryPage: React.FC<EntryProps> = ({preLoadedEntry, tenantId, repo, branch
                             </span>
                         </div>
 
-                        <div className="flex items-center">
+                        <div className="flex items-center mr-4">
                             <EyeIcon className="h-4 w-4 mr-1"/>
                             <Counter entryId={entryId!}/>
                         </div>
+
+                        <a
+                            href={`/entries/${entry.entryId}.md`}
+                            className="flex items-center text-meta hover:text-fg transition-colors"
+                            title="View as Markdown"
+                            data-discover="false"
+                        >
+                            <MarkdownIcon className="h-4 w-4"/>
+                        </a>
                     </div>
 
                     {/* Tags using EntryTag component */}


### PR DESCRIPTION
## Summary
- Add a button in the entry meta section that links to the raw markdown version of the entry (`/entries/{entryId}.md`)
- Add new `MarkdownIcon` component styled consistently with existing language icons (JA/EN)
- Button uses `data-discover="false"` to bypass React Router and navigate directly to the server

## Test plan
- [ ] Verify the MD button appears in the entry meta section next to view count
- [ ] Click the MD button and confirm it navigates to `/entries/{entryId}.md`
- [ ] Confirm the page reloads (not client-side navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)