### PR TITLE
Add Lab page with MOV to GIF Converter

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,9 +8,11 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "@ffmpeg/core": "^0.12.10",
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "@giscus/react": "^3.1.0",
         "@kevincobain2000/json-to-html-table": "^1.0.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
         "highlight.js": "^11.11.0",
         "javascript-time-ago": "^2.6.2",
         "marked": "^12.0.2",
@@ -1005,6 +1007,45 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@ffmpeg/core": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.12.10.tgz",
+      "integrity": "sha512-dzNplnn2Nxle2c2i2rrDhqcB19q9cglCkWnoMTDN9Q9l3PvdjZWd1HfSPjCNWc/p8Q3CT+Es9fWOR0UhAeYQZA==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
+      "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ffmpeg/types": "^0.12.4"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
+    "node_modules/@ffmpeg/types": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
+      "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/util": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+      "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@giscus/react": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ffmpeg/core": "^0.12.10",
+    "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/util": "^0.12.2",
     "@giscus/react": "^3.1.0",
     "@kevincobain2000/json-to-html-table": "^1.0.4",
     "highlight.js": "^11.11.0",

--- a/ui/src/components/MobileMenu.tsx
+++ b/ui/src/components/MobileMenu.tsx
@@ -87,8 +87,17 @@ const MobileMenu: React.FC = () => {
               </NavLink>
             </li>
             <li className="font-bold">
-              <NavLink 
-                to={'/aboutme'} 
+              <NavLink
+                to={'/lab'}
+                className={({isActive}) => isActive ? "no-underline border-b border-dashed border-1" : "no-underline"}
+                onClick={() => setIsOpen(false)}
+              >
+                Lab
+              </NavLink>
+            </li>
+            <li className="font-bold">
+              <NavLink
+                to={'/aboutme'}
                 className={({isActive}) => isActive ? "no-underline border-b border-dashed border-1" : "no-underline"}
                 onClick={() => setIsOpen(false)}
               >

--- a/ui/src/components/Navi.tsx
+++ b/ui/src/components/Navi.tsx
@@ -24,6 +24,9 @@ const Navi = () => {
                         <NavLink to={'/notes'} className={({isActive}) => isActive ? "no-underline border-b border-dashed border-1" : "no-underline"}>Notes</NavLink>
                     </li>
                     <li className="list-none inline pr-4 font-bold">
+                        <NavLink to={'/lab'} className={({isActive}) => isActive ? "no-underline border-b border-dashed border-1" : "no-underline"}>Lab</NavLink>
+                    </li>
+                    <li className="list-none inline pr-4 font-bold">
                         <NavLink to={'/aboutme'} className={({isActive}) => isActive ? "no-underline border-b border-dashed border-1" : "no-underline"}>About</NavLink>
                     </li>
                 </ul>

--- a/ui/src/ffmpeg.d.ts
+++ b/ui/src/ffmpeg.d.ts
@@ -1,0 +1,8 @@
+declare module '@ffmpeg/core?url' {
+  const url: string
+  export default url
+}
+declare module '@ffmpeg/core/wasm?url' {
+  const url: string
+  export default url
+}

--- a/ui/src/pages/lab/LabPage.tsx
+++ b/ui/src/pages/lab/LabPage.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+import {OGP} from '../../components/OGP.tsx';
+import PageHeader from '../../components/PageHeader.tsx';
+import Card from '../../components/Card.tsx';
+
+interface LabTool {
+    title: string;
+    description: string;
+    path: string;
+}
+
+const tools: LabTool[] = [
+    {
+        title: 'MOV to GIF Converter',
+        description: 'Convert video files to GIF animations entirely in your browser using FFmpeg WebAssembly.',
+        path: '/lab/mov-to-gif',
+    },
+];
+
+const accentColor = '#F4E878';
+
+const LabPage: React.FC = () => {
+    return (
+        <>
+            <OGP title="Lab - IK.AM"/>
+            <PageHeader title="Lab"
+                        description="Experimental tools and utilities."/>
+            <div className="space-y-4">
+                {tools.map(tool => (
+                    <Card key={tool.path}
+                          accentColor={accentColor}
+                          isHighlighted={true}>
+                        <Link to={tool.path}
+                              className="block mb-2 font-medium text-base hover:underline">
+                            {tool.title}
+                        </Link>
+                        <p className="text-sm text-fg2/80 mb-0">{tool.description}</p>
+                    </Card>
+                ))}
+            </div>
+        </>
+    );
+};
+
+export default LabPage

--- a/ui/src/pages/lab/MovToGifConverter.tsx
+++ b/ui/src/pages/lab/MovToGifConverter.tsx
@@ -11,9 +11,9 @@ const MovToGifConverter: React.FC = () => {
     const [converting, setConverting] = useState(false)
     const [progress, setProgress] = useState(0)
     const [logMessages, setLogMessages] = useState<string[]>([])
-    const [scale, setScale] = useState(720)
-    const [fps, setFps] = useState(10)
-    const [quality, setQuality] = useState<'low' | 'medium' | 'high'>('medium')
+    const [scale, setScale] = useState('720')
+    const [fps, setFps] = useState('10')
+    const [quality, setQuality] = useState<'low' | 'medium' | 'high'>('low')
     const [speed, setSpeed] = useState(1)
     const [dragOver, setDragOver] = useState(false)
     const [loadError, setLoadError] = useState<string | null>(null)
@@ -89,9 +89,11 @@ const MovToGifConverter: React.FC = () => {
         try {
             await ffmpeg.writeFile('input.mov', await fetchFile(inputFile))
 
+            const scaleVal = parseInt(scale, 10) || 720
+            const fpsVal = parseInt(fps, 10) || 10
             const speedFilter = speed !== 1 ? `setpts=${(1 / speed).toFixed(4)}*PTS,` : ''
-            const fpsFilter = `fps=${fps},`
-            const scaleFilter = `scale=${scale}:-1:flags=lanczos`
+            const fpsFilter = `fps=${fpsVal},`
+            const scaleFilter = `scale=${scaleVal}:-1:flags=lanczos`
 
             if (quality === 'high') {
                 const paletteVf = `${speedFilter}${fpsFilter}${scaleFilter},palettegen=max_colors=256:stats_mode=diff`
@@ -203,10 +205,9 @@ const MovToGifConverter: React.FC = () => {
                     <input
                         type="number"
                         value={scale}
-                        onChange={e => setScale(Number(e.target.value))}
+                        onChange={e => setScale(e.target.value)}
                         min={100}
                         max={1920}
-                        step={10}
                         className={inputClasses}
                     />
                 </div>
@@ -215,7 +216,7 @@ const MovToGifConverter: React.FC = () => {
                     <input
                         type="number"
                         value={fps}
-                        onChange={e => setFps(Number(e.target.value))}
+                        onChange={e => setFps(e.target.value)}
                         min={1}
                         max={30}
                         className={inputClasses}

--- a/ui/src/pages/lab/MovToGifConverter.tsx
+++ b/ui/src/pages/lab/MovToGifConverter.tsx
@@ -1,0 +1,301 @@
+import {useState, useRef, useEffect, useCallback} from 'react'
+import {FFmpeg} from '@ffmpeg/ffmpeg'
+import {fetchFile} from '@ffmpeg/util'
+import coreURL from '@ffmpeg/core?url'
+import wasmURL from '@ffmpeg/core/wasm?url'
+
+const MovToGifConverter: React.FC = () => {
+    const [loaded, setLoaded] = useState(false)
+    const [inputFile, setInputFile] = useState<File | null>(null)
+    const [outputURL, setOutputURL] = useState<string | null>(null)
+    const [converting, setConverting] = useState(false)
+    const [progress, setProgress] = useState(0)
+    const [logMessages, setLogMessages] = useState<string[]>([])
+    const [scale, setScale] = useState(720)
+    const [fps, setFps] = useState(10)
+    const [quality, setQuality] = useState<'low' | 'medium' | 'high'>('medium')
+    const [speed, setSpeed] = useState(1)
+    const [dragOver, setDragOver] = useState(false)
+    const [loadError, setLoadError] = useState<string | null>(null)
+
+    const ffmpegRef = useRef(new FFmpeg())
+    const fileInputRef = useRef<HTMLInputElement>(null)
+
+    useEffect(() => {
+        const load = async () => {
+            const ffmpeg = ffmpegRef.current
+
+            ffmpeg.on('progress', ({progress: p}) => {
+                if (p > 0 && p < 1) {
+                    setProgress(Math.round(p * 100))
+                }
+            })
+
+            ffmpeg.on('log', ({message}) => {
+                setLogMessages(prev => [...prev.slice(-99), message])
+            })
+
+            try {
+                await ffmpeg.load({coreURL, wasmURL})
+                setLoaded(true)
+            } catch (e) {
+                console.error('Failed to load FFmpeg:', e)
+                setLoadError(e instanceof Error ? e.message : 'Unknown error')
+            }
+        }
+
+        load()
+    }, [])
+
+    const handleFile = useCallback((file: File) => {
+        setInputFile(file)
+        setOutputURL(null)
+        setProgress(0)
+        setLogMessages([])
+    }, [])
+
+    const handleDrop = useCallback((e: React.DragEvent) => {
+        e.preventDefault()
+        setDragOver(false)
+        const file = e.dataTransfer.files[0]
+        if (file) handleFile(file)
+    }, [handleFile])
+
+    const handleDragOver = useCallback((e: React.DragEvent) => {
+        e.preventDefault()
+        setDragOver(true)
+    }, [])
+
+    const handleDragLeave = useCallback((e: React.DragEvent) => {
+        e.preventDefault()
+        setDragOver(false)
+    }, [])
+
+    const handleFileInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (file) handleFile(file)
+    }, [handleFile])
+
+    const convert = async () => {
+        if (!inputFile || !loaded) return
+
+        setConverting(true)
+        setProgress(0)
+        setLogMessages([])
+        setOutputURL(null)
+
+        const ffmpeg = ffmpegRef.current
+
+        try {
+            await ffmpeg.writeFile('input.mov', await fetchFile(inputFile))
+
+            const speedFilter = speed !== 1 ? `setpts=${(1 / speed).toFixed(4)}*PTS,` : ''
+            const fpsFilter = `fps=${fps},`
+            const scaleFilter = `scale=${scale}:-1:flags=lanczos`
+
+            if (quality === 'high') {
+                const paletteVf = `${speedFilter}${fpsFilter}${scaleFilter},palettegen=max_colors=256:stats_mode=diff`
+                await ffmpeg.exec([
+                    '-i', 'input.mov',
+                    '-vf', paletteVf,
+                    'palette.png',
+                ])
+                const outputVf = `${speedFilter}${fpsFilter}${scaleFilter} [x]; [x][1:v] paletteuse=dither=floyd_steinberg`
+                await ffmpeg.exec([
+                    '-i', 'input.mov',
+                    '-i', 'palette.png',
+                    '-lavfi', outputVf,
+                    'output.gif',
+                ])
+            } else {
+                const ditherOpt = quality === 'medium'
+                    ? ',split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3'
+                    : ''
+                const vf = `${speedFilter}${fpsFilter}${scaleFilter}${ditherOpt}`
+                await ffmpeg.exec([
+                    '-i', 'input.mov',
+                    '-vf', vf,
+                    'output.gif',
+                ])
+            }
+
+            const data = await ffmpeg.readFile('output.gif') as Uint8Array
+            const blob = new Blob([(data as unknown as BlobPart)], {type: 'image/gif'})
+            setOutputURL(URL.createObjectURL(blob))
+        } catch (e) {
+            console.error('Conversion failed:', e)
+            setLogMessages(prev => [...prev, `Error: ${e instanceof Error ? e.message : 'Conversion failed'}`])
+        } finally {
+            setConverting(false)
+        }
+    }
+
+    const downloadGif = () => {
+        if (!outputURL) return
+        const a = document.createElement('a')
+        a.href = outputURL
+        const baseName = inputFile?.name.replace(/\.[^.]+$/, '') ?? 'output'
+        a.download = `${baseName}.gif`
+        a.click()
+    }
+
+    const statusBadge = (
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+            loaded
+                ? 'bg-(color:--tag-bg) text-(color:--tag-text)'
+                : loadError
+                    ? 'bg-(color:--entry-meta-bg) text-fg'
+                    : 'bg-(color:--tag-bg) text-(color:--tag-text)'
+        }`}>
+            {loaded ? 'Ready' : loadError ? 'Load failed' : 'Loading FFmpeg...'}
+        </span>
+    )
+
+    const inputClasses = 'w-full px-3 py-2 rounded-md border border-(color:--empty-border) bg-(color:--card-bg) text-fg text-sm focus:outline-none focus:ring-2 focus:ring-(color:--accent)'
+    const labelClasses = 'text-sm font-medium text-fg2'
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center gap-2 mb-4">
+                <span className="text-sm text-fg2">Status:</span>
+                {statusBadge}
+            </div>
+
+            {/* Drop zone */}
+            <div
+                className={`relative border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                    dragOver
+                        ? 'border-(color:--accent) bg-(color:--card-hover-bg)'
+                        : inputFile
+                            ? 'border-(color:--empty-border) bg-(color:--card-bg)'
+                            : 'border-(color:--empty-border) hover:border-fg2'
+                }`}
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onClick={() => fileInputRef.current?.click()}
+            >
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="video/*,.mov"
+                    onChange={handleFileInput}
+                    hidden
+                />
+                {inputFile ? (
+                    <div className="space-y-1">
+                        <p className="text-lg font-semibold text-fg">{inputFile.name}</p>
+                        <p className="text-sm text-fg2">{(inputFile.size / 1024 / 1024).toFixed(1)} MB</p>
+                        <p className="text-xs text-fg2">Click or drop to change file</p>
+                    </div>
+                ) : (
+                    <div className="space-y-2">
+                        <p className="text-4xl text-fg2">+</p>
+                        <p className="text-fg2">Drop a video file here or click to select</p>
+                    </div>
+                )}
+            </div>
+
+            {/* Settings */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <div className="space-y-1">
+                    <label className={labelClasses}>Width (px)</label>
+                    <input
+                        type="number"
+                        value={scale}
+                        onChange={e => setScale(Number(e.target.value))}
+                        min={100}
+                        max={1920}
+                        step={10}
+                        className={inputClasses}
+                    />
+                </div>
+                <div className="space-y-1">
+                    <label className={labelClasses}>FPS</label>
+                    <input
+                        type="number"
+                        value={fps}
+                        onChange={e => setFps(Number(e.target.value))}
+                        min={1}
+                        max={30}
+                        className={inputClasses}
+                    />
+                </div>
+                <div className="space-y-1">
+                    <label className={labelClasses}>Quality</label>
+                    <select
+                        value={quality}
+                        onChange={e => setQuality(e.target.value as 'low' | 'medium' | 'high')}
+                        className={inputClasses}
+                    >
+                        <option value="low">Low (fast)</option>
+                        <option value="medium">Medium</option>
+                        <option value="high">High (slow)</option>
+                    </select>
+                </div>
+                <div className="space-y-1">
+                    <label className={labelClasses}>Speed</label>
+                    <select
+                        value={speed}
+                        onChange={e => setSpeed(Number(e.target.value))}
+                        className={inputClasses}
+                    >
+                        <option value={0.25}>0.25x</option>
+                        <option value={0.5}>0.5x</option>
+                        <option value={1}>1x</option>
+                        <option value={1.5}>1.5x</option>
+                        <option value={2}>2x</option>
+                        <option value={4}>4x</option>
+                    </select>
+                </div>
+            </div>
+
+            {/* Convert button */}
+            <button
+                className="w-full py-3 px-4 rounded-[0.35rem] font-semibold bg-fg text-bg hover:bg-fg2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-300"
+                onClick={convert}
+                disabled={!loaded || !inputFile || converting}
+            >
+                {converting ? `Converting... ${progress}%` : 'Convert to GIF'}
+            </button>
+
+            {/* Progress bar */}
+            {converting && (
+                <div className="w-full h-2 bg-(color:--card-bg) rounded-full overflow-hidden border border-(color:--empty-border)">
+                    <div
+                        className="h-full bg-fg transition-all duration-300"
+                        style={{width: `${progress}%`}}
+                    />
+                </div>
+            )}
+
+            {/* Result */}
+            {outputURL && (
+                <div className="space-y-4 p-4 rounded-lg bg-(color:--card-bg) border border-(color:--empty-border)">
+                    <h3 className="text-lg font-semibold text-fg">Result</h3>
+                    <img src={outputURL} alt="Converted GIF" className="max-w-full rounded-md"/>
+                    <button
+                        className="py-2 px-6 rounded-[0.35rem] font-semibold bg-fg text-bg hover:bg-fg2 transition-colors duration-300"
+                        onClick={downloadGif}
+                    >
+                        Download GIF
+                    </button>
+                </div>
+            )}
+
+            {/* Log */}
+            {logMessages.length > 0 && (
+                <details className="rounded-lg bg-(color:--card-bg) border border-(color:--empty-border)">
+                    <summary className="px-4 py-2 cursor-pointer text-sm font-medium text-fg2">
+                        FFmpeg Log ({logMessages.length})
+                    </summary>
+                    <pre className="px-4 py-2 text-xs !text-fg !bg-(color:--card-bg) border-none overflow-x-auto max-h-48 overflow-y-auto">
+                        {logMessages.join('\n')}
+                    </pre>
+                </details>
+            )}
+        </div>
+    )
+}
+
+export default MovToGifConverter

--- a/ui/src/pages/lab/MovToGifPage.tsx
+++ b/ui/src/pages/lab/MovToGifPage.tsx
@@ -1,0 +1,19 @@
+import React, {lazy, Suspense} from 'react';
+import {OGP} from '../../components/OGP.tsx';
+import PageHeader from '../../components/PageHeader.tsx';
+import Loading from '../../components/Loading.tsx';
+
+const MovToGifConverter = lazy(() => import('./MovToGifConverter'))
+
+const MovToGifPage: React.FC = () => (
+    <>
+        <OGP title="MOV to GIF Converter - Lab - IK.AM"/>
+        <PageHeader title="MOV to GIF Converter"
+                    description="Convert video files to GIF animations entirely in your browser."/>
+        <Suspense fallback={<Loading/>}>
+            <MovToGifConverter/>
+        </Suspense>
+    </>
+)
+
+export default MovToGifPage

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -7,6 +7,8 @@ import CategoriesPage, {CategoriesProps} from "./pages/entry/CategoriesPage.tsx"
 import en from 'javascript-time-ago/locale/en'
 import TimeAgo from "javascript-time-ago";
 import AboutMePage from "./pages/etc/AboutMePage.tsx";
+import LabPage from "./pages/lab/LabPage.tsx";
+import MovToGifPage from "./pages/lab/MovToGifPage.tsx";
 import Error404Page from "./pages/etc/Error404Page.tsx";
 import InfoPage from "./components/InfoPage.tsx";
 import LoginPage from "./pages/note/LoginPage.tsx";
@@ -97,6 +99,12 @@ export default function routes(initData: object): RouteObject[] {
                 },
                 {
                     path: "/aboutme", element: <AboutMePage/>
+                },
+                {
+                    path: "/lab", element: <LabPage/>
+                },
+                {
+                    path: "/lab/mov-to-gif", element: <MovToGifPage/>
                 },
                 {
                     path: "/info", element: <InfoPage/>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,7 +5,11 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
     plugins: [react()],
     ssr: {
-        noExternal: true
+        noExternal: true,
+        external: ['@ffmpeg/ffmpeg', '@ffmpeg/util', '@ffmpeg/core'],
+    },
+    optimizeDeps: {
+        exclude: ['@ffmpeg/ffmpeg', '@ffmpeg/util', '@ffmpeg/core'],
     },
     server: {
         proxy: {


### PR DESCRIPTION
## Summary
- Add new "Lab" section (`/lab`) for experimental browser-based tools
- Add MOV to GIF converter (`/lab/mov-to-gif`) powered by FFmpeg WebAssembly - runs entirely in the browser
- Features: drag-and-drop upload, configurable width/fps/quality/speed, progress bar, download
- SSR-safe via `React.lazy` code splitting; Vite configured to exclude `@ffmpeg` from SSR bundling
- Apply `fps` filter before `split` in filter chain to prevent OOM on large/high-fps videos

## Test plan
- [ ] Verify `/lab` page displays tool cards correctly
- [ ] Verify `/lab/mov-to-gif` loads FFmpeg and shows "Ready" status
- [ ] Test drag-and-drop and file picker with a MOV/MP4 file
- [ ] Test all quality levels (Low/Medium/High) with a large video (~9MB)
- [ ] Test speed/fps/width settings
- [ ] Verify dark mode displays correctly (buttons, log, status badge)
- [ ] Verify Lab link appears in both desktop and mobile navigation
- [ ] Verify SSR build succeeds (`./mvnw clean package`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)